### PR TITLE
Email receipt now displays attachment link

### DIFF
--- a/give-receipt-attachments.php
+++ b/give-receipt-attachments.php
@@ -41,17 +41,19 @@ if ( ! defined( 'GIVERA_VERSION' ) ) {
 // If not, it bails with an Admin notice as to why. 
 // If so, it loads the necessary files and scripts
 
-add_action( 'init', 'givera_plugin_init' );
+add_action( 'give_init', 'givera_plugin_init' );
 
 function givera_plugin_init() {
 
-	if ( current_user_can( 'activate_plugins' ) && !class_exists('Give') ) {
+	if ( current_user_can( 'activate_plugins' ) && ! class_exists( 'Give' ) ) {
 
 		add_action( 'admin_notices', 'givera_no_give_admin_notice' );
 		add_action( 'admin_init', 'givera_deactivate' );
 
-	} elseif ( class_exists('Give') &&
-	           version_compare( GIVE_VERSION, GIVERA_MIN_GIVE_VER, '<'  ) ) {
+	} elseif (
+		class_exists( 'Give' ) &&
+		version_compare( GIVE_VERSION, GIVERA_MIN_GIVE_VER, '<' )
+	) {
 
 		add_action( 'admin_notices', 'givera_min_give_admin_notice' );
 		add_action( 'admin_init', 'givera_deactivate' );

--- a/give-receipt-attachments.php
+++ b/give-receipt-attachments.php
@@ -29,7 +29,7 @@ if ( ! defined( 'GIVERA_BASENAME' ) ) {
 
 // Defines the minimum Give version for GIVE_RA to run
 if ( ! defined( 'GIVERA_MIN_GIVE_VER' ) ) {
-	define( 'GIVERA_MIN_GIVE_VER', '2.0' );
+	define( 'GIVERA_MIN_GIVE_VER', '2.13.4' );
 }
 
 // Defines Add-on Version number for easy reference


### PR DESCRIPTION
## Description

Resolves #13 

I find out that we were loading the plugin on `init` action hook and email tags also register on `init` action hook, so this addon email tag does not register. I updated the code to load on `give_init`, so help addon to register email tags correctly.


## Visuals
![MailHog 2021-09-22 at 10 16 51 PM](https://user-images.githubusercontent.com/1784821/134386673-338a4a00-7f79-4436-ba60-a8f602cb5970.jpg)
